### PR TITLE
feat: Add youtube videos to demos

### DIFF
--- a/docs/partial_conf.py
+++ b/docs/partial_conf.py
@@ -3,13 +3,36 @@ from docs.conf import html_theme_options
 
 html_theme_options["switcher"]["json_url"] = "https://unify.ai/docs/versions/ivy.json"
 
+youtube_map = {
+    # TODO: Add video tutorials
+    # "quickstart": "tmhFTFSEa6k",
+}
+
 nbsphinx_execute = 'never'
 nbsphinx_prolog = """
-|Open in Colab| |Github|
-
 .. |Open in Colab| image:: https://colab.research.google.com/assets/colab-badge.svg
     :target: https://colab.research.google.com/github/unifyai/demos/blob/main/docs/{{ env.doc2path(env.docname, base=None) }}
 
 .. |Github| image:: https://badgen.net/badge/icon/github?icon=github&label
     :target: https://github.com/unifyai/demos/blob/main/docs/{{ env.doc2path(env.docname, base=None) }}
+
+{% if env.config.youtube_map[env.docname] %}
+.. raw:: html
+
+    <h4 style="margin-top: .05rem;">Video Tutorial</h4>
+
+.. raw:: html
+
+    <iframe width="560" height="315" style="margin-bottom: 1rem;"
+        src="https://www.youtube.com/embed/{{ env.config.youtube_map[env.docname] }}"
+        frameborder="0" allow="encrypted-media; picture-in-picture" allowfullscreen>
+    </iframe>
+    <br>
+{% endif %}
+
+|Open in Colab| |Github|
 """
+
+
+def setup(app):
+    app.add_config_value("youtube_map", youtube_map, "env")


### PR DESCRIPTION
In this PR I've added the ability to control youtube videos through [`partial_conf.py`](https://github.com/unifyai/demos/pull/56/files#diff-be41971b977e674d0362f178abff240e8940db3dc3d524559cf8d672c406c148), with coordination with @albert-dl.

This how the page should look like when adding youtube links:
<img width="827" alt="image" src="https://github.com/unifyai/demos/assets/16426366/b32ad234-695d-4514-a017-58e08a980c53">
