### PR TITLE
perf: moved the model and inputs to gpu:0 before transpilation

### DIFF
--- a/examples_and_demos/torch_to_jax.ipynb
+++ b/examples_and_demos/torch_to_jax.ipynb
@@ -93,7 +93,7 @@
         "checkpoint_name = \"microsoft/resnet-50\"\n",
         "\n",
         "feature_extractor = AutoFeatureExtractor.from_pretrained(checkpoint_name)\n",
-        "model = AutoModel.from_pretrained(checkpoint_name)"
+        "model = AutoModel.from_pretrained(checkpoint_name).to('cuda')"
       ]
     },
     {
@@ -117,7 +117,7 @@
         "image = Image.open(requests.get(url, stream=True).raw)\n",
         "inputs = feature_extractor(\n",
         "    images=image, return_tensors=\"pt\"\n",
-        ")"
+        ").to('cuda')"
       ]
     },
     {
@@ -164,8 +164,6 @@
         "inputs = feature_extractor(\n",
         "    images=image, return_tensors=\"pt\"\n",
         ").to(\"cuda\")\n",
-        "\n",
-        "model.to(\"cuda\")\n",
         "\n",
         "def _f(**kwargs):\n",
         "  return model(**kwargs)\n",


### PR DESCRIPTION
they weren't gpu arrays orginally because the default device with native torch code is a cpu and we weren't using any ivy's creation functions which would consider gpu as the default device