### PR TITLE
Added set_default_device(gpu:0) to the demos as model creation isn't working with latest ivy

### DIFF
--- a/examples_and_demos/alexnet_demo.ipynb
+++ b/examples_and_demos/alexnet_demo.ipynb
@@ -175,6 +175,7 @@
       "outputs": [],
       "source": [
         "import ivy\n",
+        "ivy.set_default_device(\"gpu:0\")\n",
         "ivy.set_backend(\"torch\")\n",
         "\n",
         "from ivy_models.alexnet import alexnet\n",

--- a/examples_and_demos/bert_demo.ipynb
+++ b/examples_and_demos/bert_demo.ipynb
@@ -81,6 +81,7 @@
       "source": [
         "import torch\n",
         "import ivy\n",
+        "ivy.set_default_device(\"gpu:0\")\n",
         "import ivy_models\n",
         "from transformers import AutoModel, AutoTokenizer\n",
         "import warnings\n",

--- a/examples_and_demos/image_segmentation_with_ivy_unet.ipynb
+++ b/examples_and_demos/image_segmentation_with_ivy_unet.ipynb
@@ -60,6 +60,7 @@
       "outputs": [],
       "source": [
         "import ivy\n",
+        "ivy.set_default_device(\"gpu:0\")\n",
         "import torch\n",
         "import numpy as np"
       ]

--- a/examples_and_demos/mmpretrain_to_jax.ipynb
+++ b/examples_and_demos/mmpretrain_to_jax.ipynb
@@ -61,6 +61,7 @@
       "source": [
         "import jax\n",
         "import ivy\n",
+        "ivy.set_default_device(\"gpu:0\")\n",
         "import torch\n",
         "import requests\n",
         "import numpy as np\n",

--- a/examples_and_demos/resnet_demo.ipynb
+++ b/examples_and_demos/resnet_demo.ipynb
@@ -70,6 +70,7 @@
       "outputs": [],
       "source": [
         "import ivy\n",
+        "ivy.set_default_device(\"gpu:0\")\n",
         "import torch"
       ]
     },

--- a/examples_and_demos/torch_to_jax.ipynb
+++ b/examples_and_demos/torch_to_jax.ipynb
@@ -63,6 +63,7 @@
       "source": [
         "import jax\n",
         "import ivy\n",
+        "ivy.set_default_device(\"gpu:0\")\n",
         "import torch\n",
         "import requests\n",
         "import numpy as np\n",


### PR DESCRIPTION
model creation isn't working with the default device being a cpu which is the default in ivy currently so it would be a blocker for the release otherwise